### PR TITLE
Support multiple connections for servers urls that have common wildcard certificates

### DIFF
--- a/web_page_replay_go/src/httparchive.go
+++ b/web_page_replay_go/src/httparchive.go
@@ -8,28 +8,61 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
 	"io"
 	"io/ioutil"
+
+	//"log"
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 
-	"github.com/catapult-project/catapult/web_page_replay_go/src/webpagereplay"
+	//"path/filepath"
+	"strings"
+	"time"
+
+	"./webpagereplay"
 	"github.com/urfave/cli"
 )
 
 const usage = "%s [ls|cat|edit|merge|add|addAll] [options] archive_file [output_file] [url]"
 
+/*type CertConfig struct {
+	// Flags common to all commands.
+	certFile, keyFile string
+}
+
+func (certCfg *CertConfig) Flags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:        "https_cert_file",
+			Value:       "wpr_cert.pem",
+			Usage:       "File containing a PEM-encoded X509 certificate to use with SSL.",
+			Destination: &certCfg.certFile,
+		},
+		cli.StringFlag{
+			Name:        "https_key_file",
+			Value:       "wpr_key.pem",
+			Usage:       "File containing a PEM-encoded private key to use with SSL.",
+			Destination: &certCfg.keyFile,
+		},
+	}
+}*/
+
 type Config struct {
 	method, host, fullPath                              string
 	decodeResponseBody, skipExisting, overwriteExisting bool
+	certConfig                                          CertConfig
+	root_cert                                           tls.Certificate
 }
 
 func (cfg *Config) DefaultFlags() []cli.Flag {
-	return []cli.Flag{
+	return append(cfg.certConfig.Flags(),
 		cli.StringFlag{
 			Name:        "command",
 			Value:       "",
@@ -53,7 +86,8 @@ func (cfg *Config) DefaultFlags() []cli.Flag {
 			Usage:       "Decode/encode response body according to Content-Encoding header.",
 			Destination: &cfg.decodeResponseBody,
 		},
-	}
+	)
+
 }
 
 func (cfg *Config) AddFlags() []cli.Flag {
@@ -272,6 +306,105 @@ func addAll(cfg *Config, archive *webpagereplay.Archive, outfile string, inputFi
 	return writeArchive(archive, outfile)
 }
 
+func certEdit(cfg *Config, archive *webpagereplay.Archive, outfile string, inputFilePath string) error {
+
+	var ipMap = make(map[string][]string)
+
+	for host, ip := range archive.RemoteAddresses {
+		if h, ok := ipMap[ip]; ok {
+			h = append(h, host)
+			ipMap[ip] = h
+		} else {
+			ipMap[ip] = []string{host}
+		}
+	}
+
+	for ip := range ipMap {
+		for i := range ipMap[ip] {
+			currentSANList := []string{ipMap[ip][i]}
+			currentCert, err := x509.ParseCertificate(archive.Certs[ipMap[ip][i]])
+			//derBytes, negotiatedProtocol, ip, err := archive.FindHostTLSConfig(i)
+			if err != nil {
+				return err
+			}
+			for j := range ipMap[ip] {
+				if j != i {
+					certValidationErr := currentCert.VerifyHostname(ipMap[ip][j])
+					if certValidationErr == nil {
+						currentSANList = append(currentSANList, ipMap[ip][j])
+					}
+				}
+			}
+			fakecert, e := x509.ParseCertificate(cfg.root_cert.Certificate[0])
+
+			if e != nil {
+				println(fmt.Sprintf("New Cert DNS : %v", e))
+			}
+
+			newCert, err := CreateDomainRestrictedCert(currentSANList, currentCert, fakecert, cfg.root_cert.PrivateKey)
+			newCertParsed, er := x509.ParseCertificate(newCert)
+			if er == nil {
+				println(fmt.Sprintf("New Cert CN: %s", newCertParsed.Subject.CommonName))
+				println(fmt.Sprintf("Old Cert CN: %s", currentCert.Subject.CommonName))
+
+				for str := range newCertParsed.DNSNames {
+					println(fmt.Sprintf("IP: %s New Cert DNS : %s", ip, newCertParsed.DNSNames[str]))
+				}
+				for str := range currentCert.DNSNames {
+					println(fmt.Sprintf("IP: %s Old Cert DNS : %s", ip, currentCert.DNSNames[str]))
+				}
+			}
+
+			archive.Certs[ipMap[ip][i]] = newCert
+
+		}
+	}
+
+	return writeArchive(archive, outfile)
+}
+
+//Mints a restricted certificate that is only valid for the SANs in the certificateSAN parameter
+func CreateDomainRestrictedCert(certificateSANs []string, rootCert *x509.Certificate, fakecert *x509.Certificate, rootKey crypto.PrivateKey) ([]byte, error) {
+	template := x509.Certificate{
+
+		SerialNumber: rootCert.SerialNumber,
+
+		Subject: pkix.Name{
+
+			CommonName: certificateSANs[0],
+		},
+
+		Issuer: fakecert.Subject,
+
+		NotBefore: time.Now(),
+
+		NotAfter: time.Now().Add(time.Hour * 24 * 180),
+
+		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign,
+
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+
+		BasicConstraintsValid: true,
+
+		IsCA: true,
+
+		AuthorityKeyId: rootCert.AuthorityKeyId,
+
+		CRLDistributionPoints: rootCert.CRLDistributionPoints,
+
+		IssuingCertificateURL: rootCert.IssuingCertificateURL,
+
+		DNSNames: certificateSANs,
+
+		PublicKey: rootCert.PublicKey,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, fakecert, fakecert.PublicKey, rootKey)
+
+	return derBytes, err
+
+}
+
 // compressResponse compresses resp.Body in place according to resp's Content-Encoding header.
 func compressResponse(resp *http.Response) error {
 	ce := strings.ToLower(resp.Header.Get("Content-Encoding"))
@@ -295,6 +428,7 @@ func compressResponse(resp *http.Response) error {
 	return nil
 }
 
+/*
 func main() {
 	progName := filepath.Base(os.Args[0])
 	cfg := &Config{}
@@ -309,6 +443,15 @@ func main() {
 		return func(c *cli.Context) error {
 			if len(c.Args()) != wantArgs {
 				return fmt.Errorf("Expected %d arguments but got %d", wantArgs, len(c.Args()))
+			}
+			cfg.certConfig.certFile = "wpr_cert.pem"
+			cfg.certConfig.keyFile = "wpr_key.pem"
+			log.Printf("Loading cert from %v\n", cfg.certConfig.certFile)
+			log.Printf("Loading key from %v\n", cfg.certConfig.keyFile)
+			var err error
+			cfg.root_cert, err = tls.LoadX509KeyPair(cfg.certConfig.certFile, cfg.certConfig.keyFile)
+			if err != nil {
+				return fmt.Errorf("error opening cert or key files: %v", err)
 			}
 			return nil
 		}
@@ -329,7 +472,7 @@ func main() {
 			ArgsUsage: "archive",
 			Flags:     cfg.DefaultFlags(),
 			Before:    checkArgs("ls", 1),
-			Action:    func(c *cli.Context) error {
+			Action: func(c *cli.Context) error {
 				return list(cfg, loadArchiveOrDie(c, 0), false)
 			},
 		},
@@ -339,7 +482,7 @@ func main() {
 			ArgsUsage: "archive",
 			Flags:     cfg.DefaultFlags(),
 			Before:    checkArgs("cat", 1),
-			Action:    func(c *cli.Context) error {
+			Action: func(c *cli.Context) error {
 				return list(cfg, loadArchiveOrDie(c, 0), true)
 			},
 		},
@@ -349,7 +492,7 @@ func main() {
 			ArgsUsage: "input_archive output_archive",
 			Flags:     cfg.DefaultFlags(),
 			Before:    checkArgs("edit", 2),
-			Action:    func(c *cli.Context) error {
+			Action: func(c *cli.Context) error {
 				return edit(cfg, loadArchiveOrDie(c, 0), c.Args().Get(1))
 			},
 		},
@@ -358,7 +501,7 @@ func main() {
 			Usage:     "Merge the requests/responses of two archives",
 			ArgsUsage: "base_archive input_archive output_archive",
 			Before:    checkArgs("merge", 3),
-			Action:    func(c *cli.Context) error {
+			Action: func(c *cli.Context) error {
 				return merge(cfg, loadArchiveOrDie(c, 0), loadArchiveOrDie(c, 1), c.Args().Get(2))
 			},
 		},
@@ -367,13 +510,13 @@ func main() {
 			Usage:     "Add a simple GET request from the network to the archive",
 			ArgsUsage: "input_archive output_archive [urls...]",
 			Flags:     cfg.AddFlags(),
-			Before:    func(c *cli.Context) error {
+			Before: func(c *cli.Context) error {
 				if len(c.Args()) < 3 {
 					return fmt.Errorf("Expected at least 3 arguments but got %d", len(c.Args()))
 				}
 				return nil
 			},
-			Action:    func(c *cli.Context) error {
+			Action: func(c *cli.Context) error {
 				return add(cfg, loadArchiveOrDie(c, 0), c.Args().Get(1), c.Args()[2:])
 			},
 		},
@@ -383,8 +526,18 @@ func main() {
 			ArgsUsage: "input_archive output_archive urls_file",
 			Flags:     cfg.AddFlags(),
 			Before:    checkArgs("add", 3),
-			Action:    func(c *cli.Context) error {
+			Action: func(c *cli.Context) error {
 				return addAll(cfg, loadArchiveOrDie(c, 0), c.Args().Get(1), c.Args().Get(2))
+			},
+		},
+		cli.Command{
+			Name:      "certEdit",
+			Usage:     "Transforms the certificates in the archives to only those SANs that were served from the IP address",
+			ArgsUsage: "input_archive output_archive urls_file",
+			Flags:     cfg.AddFlags(),
+			Before:    checkArgs("certEdit", 3),
+			Action: func(c *cli.Context) error {
+				return certEdit(cfg, loadArchiveOrDie(c, 0), c.Args().Get(1), c.Args().Get(2))
 			},
 		},
 	}
@@ -399,3 +552,4 @@ func main() {
 		os.Exit(1)
 	}
 }
+*/

--- a/web_page_replay_go/src/webpagereplay/archive.go
+++ b/web_page_replay_go/src/webpagereplay/archive.go
@@ -40,10 +40,10 @@ type RequestMatch struct {
 }
 
 func (requestMatch *RequestMatch) SetMatch(
-		match *ArchivedRequest,
-		request *http.Request,
-		response *http.Response,
-		ratio float64) {
+	match *ArchivedRequest,
+	request *http.Request,
+	response *http.Response,
+	ratio float64) {
 	requestMatch.Match = match
 	requestMatch.Request = request
 	requestMatch.Response = response
@@ -103,6 +103,8 @@ type Archive struct {
 	// Maps host string to the negotiated protocol. eg. "http/1.1" or "h2"
 	// If absent, will default to "http/1.1".
 	NegotiatedProtocol map[string]string
+	// Maps the remote IPs for the hosts,will be used with transforming the
+	RemoteAddresses map[string]string
 	// The time seed that was used to initialize deterministic.js.
 	DeterministicTimeSeedMs int64
 	// When an incoming request matches multiple recorded responses, whether to
@@ -147,7 +149,7 @@ func OpenArchive(path string) (*Archive, error) {
 	if err := json.Unmarshal(buf, &a); err != nil {
 		return nil, fmt.Errorf("json unmarshal failed: %v", err)
 	}
-	prepareArchiveForReplay(&a);
+	prepareArchiveForReplay(&a)
 	return &a, nil
 }
 
@@ -172,11 +174,11 @@ func (a *Archive) ForEach(f func(req *http.Request, resp *http.Response) error) 
 }
 
 // Returns the der encoded cert and negotiated protocol.
-func (a *Archive) FindHostTlsConfig(host string) ([]byte, string, error) {
+func (a *Archive) FindHostTlsConfig(host string) ([]byte, string, string, error) {
 	if cert, ok := a.Certs[host]; ok {
-		return cert, a.findHostNegotiatedProtocol(host), nil
+		return cert, a.findHostNegotiatedProtocol(host), a.findHostIPAddress(host), nil
 	}
-	return nil, "", ErrNotFound
+	return nil, "", "", ErrNotFound
 }
 
 func (a *Archive) findHostNegotiatedProtocol(host string) string {
@@ -184,6 +186,13 @@ func (a *Archive) findHostNegotiatedProtocol(host string) string {
 		return negotiatedProtocol
 	}
 	return "http/1.1"
+}
+
+func (a *Archive) findHostIPAddress(host string) string {
+	if ipAddress, ok := a.RemoteAddresses[host]; ok {
+		return ipAddress
+	}
+	return ""
 }
 
 func assertCompleteURL(url *url.URL) {
@@ -254,9 +263,9 @@ func (a *Archive) FindRequest(req *http.Request) (*http.Request, *http.Response,
 // Given an incoming request and a set of matches in the archive, identify the best match,
 // based on request headers.
 func (a *Archive) findBestMatchInArchivedRequestSet(
-		incomingReq *http.Request,
-		archivedReqs []*ArchivedRequest) (
-		*http.Request, *http.Response, error) {
+	incomingReq *http.Request,
+	archivedReqs []*ArchivedRequest) (
+	*http.Request, *http.Response, error) {
 	scheme := incomingReq.URL.Scheme
 
 	if len(archivedReqs) == 0 {
@@ -483,7 +492,7 @@ func (a *WritableArchive) RecordRequest(req *http.Request, resp *http.Response) 
 }
 
 // RecordTlsConfig records the cert used and protocol negotiated for a host.
-func (a *WritableArchive) RecordTlsConfig(host string, der_bytes []byte, negotiatedProtocol string) {
+func (a *WritableArchive) RecordTlsConfig(host string, der_bytes []byte, negotiatedProtocol string, address string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.Certs == nil {
@@ -496,6 +505,13 @@ func (a *WritableArchive) RecordTlsConfig(host string, der_bytes []byte, negotia
 		a.NegotiatedProtocol = make(map[string]string)
 	}
 	a.NegotiatedProtocol[host] = negotiatedProtocol
+
+	if a.RemoteAddresses == nil {
+		a.RemoteAddresses = make(map[string]string)
+	}
+	if _, ok := a.RemoteAddresses[host]; !ok {
+		a.RemoteAddresses[host] = address
+	}
 }
 
 // Close flushes the the archive and closes the output file.

--- a/web_page_replay_go/src/webpagereplay/legacyformatconvertor.go
+++ b/web_page_replay_go/src/webpagereplay/legacyformatconvertor.go
@@ -76,18 +76,18 @@ func (r *ConvertorConfig) recordServerCert(scheme string, serverName string, arc
 	if scheme != "https" {
 		return nil
 	}
-	derBytes, negotiatedProtocol, err := archive.Archive.FindHostTlsConfig(serverName)
+	derBytes, negotiatedProtocol, address, err := archive.Archive.FindHostTlsConfig(serverName)
 	if err == nil && derBytes != nil {
 		return err
 	}
-	derBytes, negotiatedProtocol, err = MintServerCert(serverName, r.x509Cert, r.tlsCert.PrivateKey)
+	derBytes, negotiatedProtocol, address, err = MintServerCert(serverName, r.x509Cert, r.tlsCert.PrivateKey)
 	if err != nil {
-		derBytes, negotiatedProtocol, err = MintDummyCertificate(serverName, r.x509Cert, r.tlsCert.PrivateKey)
+		derBytes, negotiatedProtocol, address, err = MintDummyCertificate(serverName, r.x509Cert, r.tlsCert.PrivateKey)
 		if err != nil {
 			return err
 		}
 	}
-	archive.RecordTlsConfig(serverName, derBytes, negotiatedProtocol)
+	archive.RecordTlsConfig(serverName, derBytes, negotiatedProtocol, address)
 	return nil
 }
 

--- a/web_page_replay_go/src/webpagereplay/proxy_test.go
+++ b/web_page_replay_go/src/webpagereplay/proxy_test.go
@@ -214,7 +214,7 @@ func TestEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenArchive: %v", err)
 	}
-	replayServer := httptest.NewServer(NewReplayingProxy(replayArchive, "http", transformers, false))
+	replayServer := httptest.NewServer(NewReplayingProxy(replayArchive, "http", transformers))
 	replayTransport := &http.Transport{
 		Proxy: func(*http.Request) (*url.URL, error) {
 			return url.Parse(replayServer.URL)

--- a/web_page_replay_go/src/webpagereplay/transformers.go
+++ b/web_page_replay_go/src/webpagereplay/transformers.go
@@ -178,18 +178,15 @@ func getCSPScriptSrcDirectiveFromHeaders(header http.Header) string {
 	}
 
 	directives := strings.Split(csp, ";")
-	default_directive := ""
 	for _, directive := range directives {
 		directive = strings.TrimSpace(directive)
-		if strings.HasPrefix(directive, "script-src") {
+		if strings.HasPrefix(directive, "script-src ") ||
+			strings.HasPrefix(directive, "default-src ") {
 			return directive
-		}
-		if strings.HasPrefix(directive, "default-src") {
-			default_directive = directive
 		}
 	}
 
-	return default_directive
+	return ""
 }
 
 // getScriptSrcNonceTokenFromCSPHeader returns the nonce token from a
@@ -228,69 +225,55 @@ func transformCSPHeader(header http.Header, injectedScriptSha256 string) {
 	if csp == "" {
 		return
 	}
-	// We prefer the 'script-src', but if it doesn't exist, we want to update a
-	// 'default-src' directive if it exists.
+
 	directives := strings.Split(csp, ";")
-	updateIndex := -1
 	for index, directive := range directives {
 		directive = strings.TrimSpace(directive)
-		if strings.HasPrefix(directive, "script-src") ||
-		   strings.HasPrefix(directive, "default-src") {
-			updateIndex = index
-			if strings.HasPrefix(directive, "script-src") {
-			  break
+		if strings.HasPrefix(directive, "script-src ") ||
+			strings.HasPrefix(directive, "default-src ") {
+			if getNonceTokenFromCSPHeaderScriptSrc(directive) != "" {
+				// If the CSP header's script-src contains a nonce, then
+				// transformCSPHeader does nothing.
+				// WPR will add the nonce token to any injected script to open the
+				// permission.
+				return
 			}
-		}
-	}
-	// No CSP policy to worry about updating.
-	if updateIndex < 0 {
-		return
-	}
-	updateDirective := directives[updateIndex]
-	if getNonceTokenFromCSPHeaderScriptSrc(updateDirective) != "" {
-		// If the CSP header's script-src contains a nonce, then
-		// transformCSPHeader does nothing.
-		// WPR will add the nonce token to any injected script to open the
-		// permission.
-		return
-	}
-	// Break the 'script-src' or 'default-src' directive into more tokens,
-	// and examine each token.
-	tokens := strings.Split(updateDirective, " ")
-	newDirective := ""
-	needsUnsafeInline := true
 
-	for _, token := range tokens {
-		token = strings.TrimSpace(token)
-		// All keyword tokens ['unsafe-inline', 'none', 'nonce-...', 'sha...'']
-		// are single-quote wrapped in the CSP headers.
-		if token == "'unsafe-inline'" {
-			needsUnsafeInline = false
+			// Break the 'script-src' directive into more tokens, and examine each
+			// token.
+			tokens := strings.Split(directive, " ")
+			newDirective := ""
+			needsUnsafeInline := true
+
+			for _, token := range tokens {
+				token = strings.TrimSpace(token)
+				if token == "'unsafe-inline'" {
+					needsUnsafeInline = false
+				}
+				// If the CSP header contains a hash, append the hash of the injected
+				// script.
+				// If a CSP specifies a hash, only inline scripts matching the hash
+				// may execute.
+				if strings.HasPrefix(token, "'sha256-") ||
+					strings.HasPrefix(token, "'sha384-") ||
+					strings.HasPrefix(token, "'sha512-") {
+					newDirective += "'sha256-" + injectedScriptSha256 + "' "
+					needsUnsafeInline = false
+				}
+
+				newDirective += token + " "
+			}
+
+			if needsUnsafeInline {
+				newDirective += "'unsafe-inline'"
+			}
+
+			directives[index] = newDirective
+			break
 		}
-		// If the CSP header contains a hash, append the hash of the injected
-		// script.
-		// If a CSP specifies a hash, only inline scripts matching the hash
-		// may execute.
-		if strings.HasPrefix(token, "'sha256-") ||
-			strings.HasPrefix(token, "'sha384-") ||
-			strings.HasPrefix(token, "'sha512-") {
-			newDirective += "'sha256-" + injectedScriptSha256 + "' "
-			needsUnsafeInline = false
-		}
-		// Don't add back 'none' to our set, as if it is the only item it
-		// follows we will be adding 'unsafe-inline' below.
-		if token == "'none'" {
-			continue
-		}
-		newDirective += token + " "
 	}
 
-	if needsUnsafeInline {
-		newDirective += "'unsafe-inline'"
-	}
-
-	directives[updateIndex] = newDirective
-	newCsp := strings.Join(directives, ";")
+	newCsp := strings.Join(directives, "; ")
 	header.Set("Content-Security-Policy", newCsp)
 }
 

--- a/web_page_replay_go/src/webpagereplay/transformers_test.go
+++ b/web_page_replay_go/src/webpagereplay/transformers_test.go
@@ -14,8 +14,6 @@ import (
 	"strconv"
 	"testing"
 	"time"
-
-	"github.com/kylelemons/godebug/pretty"
 )
 
 func TestReplaceTimeStamp(t *testing.T) {
@@ -136,61 +134,31 @@ func TestInjectScriptToGzipResponse(t *testing.T) {
 	}
 }
 
-func TestInjectScriptToResponse(t *testing.T) {
-	tests := []struct {
-		desc string
-		input string
-		want string
-	}{
-		{
-			desc:	"With CSP Nonce script-src",
-			input: "script-src 'strict-dynamic' 'nonce-2726c7f26c'",
-			want:	"<html><head><script nonce=\"2726c7f26c\">var foo = 1;</script>" +
-							"<script>document.write('<head></head>');</script></head></html>",
-		},
-		{
-			desc:	"With CSP Nonce default-src",
-			input: "default-src 'strict-dynamic' 'nonce-2726c7f26c'",
-			want:	"<html><head><script nonce=\"2726c7f26c\">var foo = 1;</script>" +
-							"<script>document.write('<head></head>');</script></head></html>",
-		},
-		{
-			desc:	"With CSP Nonce and both Default and Script",
-			input: "default-src 'self' https://foo.com;script-src 'strict-dynamic' 'nonce-2726cf26c'",
-			want:	"<html><head><script nonce=\"2726cf26c\">var foo = 1;</script>" +
-							"<script>document.write('<head></head>');</script></head></html>",
-		},
-		{
-			desc:	"With CSP Nonce and both Default and Script override",
-			input: "default-src 'self' 'nonce-99999cf26c';script-src 'strict-dynamic' 'nonce-2726cf26c'",
-			want:	"<html><head><script nonce=\"2726cf26c\">var foo = 1;</script>" +
-							"<script>document.write('<head></head>');</script></head></html>",
-		},
+func TestInjectScriptToResponseWithCspNonce(t *testing.T) {
+	script := []byte("var foo = 1;")
+	transformer := NewScriptInjector(script, nil)
+	req := http.Request{}
+	responseHeader := http.Header{
+		"Content-Type": []string{"text/html"},
+		"Content-Security-Policy": []string{
+			"script-src 'strict-dynamic' 'nonce-2726c7f26c'"}}
+	resp := http.Response{
+		StatusCode: 200,
+		Header:     responseHeader,
+		Body: ioutil.NopCloser(bytes.NewReader([]byte("<html><head><script>" +
+			"document.write('<head></head>');</script></head></html>")))}
+	transformer.Transform(&req, &resp)
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	for _, tc := range tests {
-		script := []byte("var foo = 1;")
-		transformer := NewScriptInjector(script, nil)
-		req := http.Request{}
-		responseHeader := http.Header{
-			"Content-Type": []string{"text/html"},
-			"Content-Security-Policy": []string{
-				tc.input}}
-		resp := http.Response{
-			StatusCode: 200,
-			Header:		 responseHeader,
-			Body: ioutil.NopCloser(bytes.NewReader([]byte("<html><head><script>" +
-				"document.write('<head></head>');</script></head></html>")))}
-		transformer.Transform(&req, &resp)
-		body, err := ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if diff := pretty.Compare(tc.want, string(body)); diff != "" {
-			t.Errorf("TestInjectScript scenario `%s`\nreturned diff (-want +got):\n%s",
-				tc.desc, diff)
-		}
+	expectedContent := []byte(fmt.Sprintf(
+		"<html><head><script nonce=\"2726c7f26c\">var foo = 1;</script>" +
+			"<script>document.write('<head></head>');</script></head></html>"))
+	if !bytes.Equal(expectedContent, body) {
+		t.Fatal(
+			fmt.Errorf("expected : %s \n actual: %s \n", expectedContent, body))
 	}
 }
 
@@ -217,40 +185,31 @@ func TestInjectScriptToResponseWithCspHash(t *testing.T) {
 }
 
 func TestTransformCsp(t *testing.T) {
-	tests := []struct {
-		desc string
-		input string
-		want string
-	}{
-		{
-			desc:  "Just Script",
-			input: "script-src 'self' https://foo.com;",
-			want:  "script-src 'self' https://foo.com 'unsafe-inline';",
-		},
-		{
-			desc:  "Just Default",
-			input: "default-src 'self' https://foo.com;",
-			want:  "default-src 'self' https://foo.com 'unsafe-inline';",
-		},
-		{
-			desc:  "Both Script and Default Src",
-			input: "default-src 'self' https://foo.com ; script-src 'self' 'nonce-2726c7f26c'",
-			want:  "default-src 'self' https://foo.com ; script-src 'self' 'nonce-2726c7f26c'",
-		},
-		{
-			desc:  "Both Script and Default Src No Nonce",
-			input: "default-src 'self' https://foo.com ; script-src 'self'",
-			want:  "default-src 'self' https://foo.com ; script-src 'self' 'unsafe-inline'",
-		},
-	}
+	responseHeader := http.Header{"Content-Security-Policy": {
+		"script-src 'self' https://foo.com;"}}
+	transformCSPHeader(responseHeader, "")
 
-	for _, tc := range tests {
-		responseHeader := http.Header{"Content-Security-Policy": { tc.input } }
-		transformCSPHeader(responseHeader, "")
-		got := responseHeader.Get("Content-Security-Policy")
-		if diff := pretty.Compare(tc.want, got); diff != "" {
-			t.Errorf("TransformCsp scenario `%s`\n[input(%s)]\n returned diff (-want +got):\n%s",
-				tc.desc, tc.input, diff)
-		}
-	}
+	assertEquals(t,
+		responseHeader.Get("Content-Security-Policy"),
+		"script-src 'self' https://foo.com 'unsafe-inline'; ")
+}
+
+func TestTransformCspDefaultSrc(t *testing.T) {
+	responseHeader := http.Header{"Content-Security-Policy": {
+		"default-src 'self' https://foo.com;"}}
+	transformCSPHeader(responseHeader, "")
+
+	assertEquals(t,
+		responseHeader.Get("Content-Security-Policy"),
+		"default-src 'self' https://foo.com 'unsafe-inline'; ")
+}
+
+func TestTransformCspBothScriptAndDefaultSrc(t *testing.T) {
+	responseHeader := http.Header{"Content-Security-Policy": {
+		"default-src 'self' https://foo.com;script-src 'self' 'nonce-2726c7f26c'"}}
+	transformCSPHeader(responseHeader, "")
+
+	assertEquals(t,
+		responseHeader.Get("Content-Security-Policy"),
+		"default-src 'self' https://foo.com 'unsafe-inline'; script-src 'self' 'nonce-2726c7f26c'")
 }


### PR DESCRIPTION
Current WPR behavior is to use only a single connection for different servers if the HTTP certificates match.This change generates equivalence classes based on remote IP addresses and the server certificate.