### PR TITLE
Add functions to httparchive.go to restrict certificate SANs

### DIFF
--- a/web_page_replay_go/src/webpagereplay/archive.go
+++ b/web_page_replay_go/src/webpagereplay/archive.go
@@ -40,10 +40,10 @@ type RequestMatch struct {
 }
 
 func (requestMatch *RequestMatch) SetMatch(
-		match *ArchivedRequest,
-		request *http.Request,
-		response *http.Response,
-		ratio float64) {
+	match *ArchivedRequest,
+	request *http.Request,
+	response *http.Response,
+	ratio float64) {
 	requestMatch.Match = match
 	requestMatch.Request = request
 	requestMatch.Response = response
@@ -103,6 +103,8 @@ type Archive struct {
 	// Maps host string to the negotiated protocol. eg. "http/1.1" or "h2"
 	// If absent, will default to "http/1.1".
 	NegotiatedProtocol map[string]string
+	// Maps the remote IPs for the hosts, will be used with transforming the certificate SANS
+	RemoteAddresses map[string]string
 	// The time seed that was used to initialize deterministic.js.
 	DeterministicTimeSeedMs int64
 	// When an incoming request matches multiple recorded responses, whether to
@@ -254,9 +256,9 @@ func (a *Archive) FindRequest(req *http.Request) (*http.Request, *http.Response,
 // Given an incoming request and a set of matches in the archive, identify the best match,
 // based on request headers.
 func (a *Archive) findBestMatchInArchivedRequestSet(
-		incomingReq *http.Request,
-		archivedReqs []*ArchivedRequest) (
-		*http.Request, *http.Response, error) {
+	incomingReq *http.Request,
+	archivedReqs []*ArchivedRequest) (
+	*http.Request, *http.Response, error) {
 	scheme := incomingReq.URL.Scheme
 
 	if len(archivedReqs) == 0 {
@@ -496,6 +498,7 @@ func (a *WritableArchive) RecordTlsConfig(host string, der_bytes []byte, negotia
 		a.NegotiatedProtocol = make(map[string]string)
 	}
 	a.NegotiatedProtocol[host] = negotiatedProtocol
+
 }
 
 // Close flushes the the archive and closes the output file.


### PR DESCRIPTION
WPR requests get served from a single server on playback which leads to connection reuse that would otherwise not be possible in production. e.g.The SSL cert for www.msn.com is valid for *.msn.com. This also matches c.msn.com & otf.msn.com. When testing with WPR – requests to these domains can all be served on one TCP connection.
In production , this would never occur as these domains are actually different servers (having different IP addresses).

Why is this a problem ?
• This results in fewer connections and alters the behavior of the waterfall . In cases where the additional connection set-up is on the critical path for a primary metric it could result in faster web perf metrics with WPR.

What does the fix do –
• The functions for transforming certificates records the IP addresses of the actual servers when it makes a connection to them.
• Then we edit their Subject Alternative Names fields so that only those requests which are to the same destination IP can be served on the same connection.